### PR TITLE
Update .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,8 @@ sudo: false
 
 env:
   global:
-    - ANDROID_API_LEVEL=27
-    - ANDROID_BUILD_TOOLS_VERSION=27.0.3
+    - ANDROID_API_LEVEL=28
+    - ANDROID_BUILD_TOOLS_VERSION=28.0.3
     - ANDROID_TAG=google_apis
 
 android:
@@ -39,8 +39,8 @@ before_install:
   - mkdir "$ANDROID_HOME/licenses" || true
   - echo -e "\n8933bad161af4178b1185d1a37fbf41ea5269c55" > "$ANDROID_HOME/licenses/android-sdk-license"
   - echo -e "\n84831b9409646a918e30573bab4c9c91346d8abd" > "$ANDROID_HOME/licenses/android-sdk-preview-license"
-  # A solution to avoid failure when using android 27, build-tools-27.0.2
-  - yes | sdkmanager "platforms;android-27"
+  # A solution to avoid failure when using android 28, build-tools-28.0.3
+  - yes | sdkmanager "platforms;android-28"
 
 notifications:
   email: false


### PR DESCRIPTION
Updated .travis.yml to android 28 so that the licenses for android 28 are accepted when building in Travis