### PR TITLE
feat: Add `backgroundColor` property

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
     ext.versions = [
             'kotlin'                 : '1.3.21',
-            'android_gradle'         : '3.5.0-alpha04',
+            'android_gradle'         : '3.3.2',
             'compile_sdk_version'    : 28,
             'target_sdk_version'     : 28,
             'app_min_sdk_version'    : 23,

--- a/whatsnew/src/androidTest/java/io/github/tonnyl/whatsnew/WhatsNewTest.kt
+++ b/whatsnew/src/androidTest/java/io/github/tonnyl/whatsnew/WhatsNewTest.kt
@@ -72,6 +72,16 @@ class WhatsNewTest {
     @Test
     @FlakyTest
     @Throws(Throwable::class)
+    fun testBackgroundColor() {
+        val whatsNew = WhatsNew.newInstance()
+        Assert.assertEquals(whatsNew.backgroundColor, -1)
+        whatsNew.backgroundColor = ContextCompat.getColor(activityRule.activity, R.color.colorAccent)
+        Assert.assertEquals(whatsNew.backgroundColor, Color.parseColor("#FF4081"))
+    }
+
+    @Test
+    @FlakyTest
+    @Throws(Throwable::class)
     fun testField_button() {
         val whatsNew = WhatsNew.newInstance()
 

--- a/whatsnew/src/main/java/io/github/tonnyl/whatsnew/WhatsNew.kt
+++ b/whatsnew/src/main/java/io/github/tonnyl/whatsnew/WhatsNew.kt
@@ -1,6 +1,7 @@
 package io.github.tonnyl.whatsnew
 
 import android.graphics.Color
+import android.graphics.drawable.ColorDrawable
 import android.os.Bundle
 import android.preference.PreferenceManager
 import android.view.*
@@ -30,6 +31,7 @@ class WhatsNew : DialogFragment() {
     var itemContentColor: Int? = null
     var iconColor: Int? = null
     var backgroundColorResource: Int = android.R.color.white
+    var backgroundColor: Int = -1
     var buttonBackground: Int = Color.parseColor("#000000")
     var buttonText: String = "Continue"
     var buttonTextColor: Int = Color.parseColor("#FFEB3B")
@@ -90,7 +92,11 @@ class WhatsNew : DialogFragment() {
 
         // Make the dialog fullscreen.
         val window = dialog.window ?: return
-        window.setBackgroundDrawableResource(backgroundColorResource)
+        if (backgroundColor != -1) {
+            window.setBackgroundDrawable(ColorDrawable(backgroundColor))
+        } else {
+            window.setBackgroundDrawableResource(backgroundColorResource)
+        }
         window.decorView.setPadding(0, 0, 0, 0)
         with(window.attributes) {
             gravity = Gravity.BOTTOM

--- a/whatsnew/src/main/java/io/github/tonnyl/whatsnew/item/DslItemBuilder.kt
+++ b/whatsnew/src/main/java/io/github/tonnyl/whatsnew/item/DslItemBuilder.kt
@@ -22,6 +22,7 @@ fun whatsNew(init: WhatNewsBuilder.() -> Unit): WhatsNew {
         this.itemTitleColor = list.itemTitleColor
         this.itemContentColor = list.itemContentColor
         this.backgroundColorResource = list.backgroundColorResource
+        this.backgroundColor = list.backgroundColor
         this.buttonBackground = list.buttonBackground
         this.buttonText = list.buttonText
         this.buttonTextColor = list.buttonTextColor
@@ -56,6 +57,7 @@ class WhatNewsBuilder : ArrayList<WhatsNewItem>() {
     var itemContentColor: Int? = null
     var iconColor: Int? = null
     var backgroundColorResource: Int = android.R.color.white
+    var backgroundColor: Int = -1
     var buttonBackground: Int = Color.parseColor("#000000")
     var buttonText: String = "Continue"
     var buttonTextColor: Int = Color.parseColor("#FFEB3B")


### PR DESCRIPTION
As discussed in issue #11 , This pull requests adds the `backgroundColor` property to the `WhatsNew` class. This will enable devs to use normal Color integers e.g
```
val whatsNew = WhatsNew.newInstance()
whatsNew.backgroundColor = ContextCompat.getColor(this, R.color.colorAccent)
```
or
```
val whatsNew = WhatsNew.newInstance()
whatsNew.backgroundColor = Color.parseColor("#FF0000")
```

**Note**: I've set the `backgroundColor` property to have priority over `backgroundColorResource`. So in a situation where both are specified, the `backgroundColor` property will be used.