### PR TITLE
Allow HTML to be used in the content for each item.

### DIFF
--- a/app/src/main/java/io/github/tonnyl/sample/MainActivity.kt
+++ b/app/src/main/java/io/github/tonnyl/sample/MainActivity.kt
@@ -1,13 +1,11 @@
 package io.github.tonnyl.sample
 
-import android.graphics.Color
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
-import androidx.core.content.ContextCompat
+import androidx.core.text.HtmlCompat
 import io.github.tonnyl.sample.databinding.ActivityMainBinding
 import io.github.tonnyl.whatsnew.WhatsNew
 import io.github.tonnyl.whatsnew.item.WhatsNewItem
-import io.github.tonnyl.whatsnew.util.ItemLayoutOption
 import io.github.tonnyl.whatsnew.util.PresentationOption
 
 class MainActivity : AppCompatActivity() {
@@ -25,7 +23,7 @@ class MainActivity : AppCompatActivity() {
                     WhatsNewItem("Nice Icons", "Completely customize colors, texts and icons.", R.drawable.ic_heart),
                     WhatsNewItem("Such Easy", "Setting this up only takes 2 lines of code, impressive you say?", R.drawable.ic_thumb_up),
                     WhatsNewItem("Very Sleep", "It helps you get more sleep by writing less code.", R.drawable.ic_satisfied_face),
-                    WhatsNewItem("Text Only", "No icons? Just go with plain text.", WhatsNewItem.NO_IMAGE_RES_ID)
+                    WhatsNewItem("Text Only", HtmlCompat.fromHtml("No icons? Just go with plain text <a href=\"https://github.com/TonnyL/WhatsNew\">or HTML</a>.", HtmlCompat.FROM_HTML_MODE_COMPACT), WhatsNewItem.NO_IMAGE_RES_ID)
             ).apply {
                 presentationOption = PresentationOption.DEBUG
             }

--- a/whatsnew/src/main/java/io/github/tonnyl/whatsnew/adapter/WhatsNewItemAdapter.kt
+++ b/whatsnew/src/main/java/io/github/tonnyl/whatsnew/adapter/WhatsNewItemAdapter.kt
@@ -2,6 +2,7 @@ package io.github.tonnyl.whatsnew.adapter
 
 import android.content.Context
 import android.graphics.Color
+import android.text.method.LinkMovementMethod
 import android.view.Gravity
 import android.view.LayoutInflater
 import android.view.ViewGroup
@@ -9,8 +10,8 @@ import android.widget.RelativeLayout
 import androidx.appcompat.content.res.AppCompatResources
 import androidx.core.graphics.drawable.DrawableCompat
 import androidx.recyclerview.widget.RecyclerView
-import io.github.tonnyl.whatsnew.databinding.WhatsnewItemIosBinding
 import io.github.tonnyl.whatsnew.databinding.WhatsnewItemBinding
+import io.github.tonnyl.whatsnew.databinding.WhatsnewItemIosBinding
 import io.github.tonnyl.whatsnew.item.WhatsNewItem
 import io.github.tonnyl.whatsnew.util.ItemLayoutOption
 
@@ -45,6 +46,7 @@ class WhatsNewItemAdapter(
                         itemTitleTextView.text = mData[position].title
                         itemTitleTextView.setTextColor(titleColor)
                         itemContentTextView.text = mData[position].content
+                        itemContentTextView.movementMethod = LinkMovementMethod.getInstance()
                         itemContentTextView.setTextColor(contentColor)
                     }
                 }
@@ -64,6 +66,7 @@ class WhatsNewItemAdapter(
                         itemTitleTextView.text = mData[position].title
                         itemTitleTextView.setTextColor(titleColor)
                         itemContentTextView.text = mData[position].content
+                        itemContentTextView.movementMethod = LinkMovementMethod.getInstance()
                         itemContentTextView.setTextColor(contentColor)
                     }
                 }

--- a/whatsnew/src/main/java/io/github/tonnyl/whatsnew/item/WhatsNewItem.kt
+++ b/whatsnew/src/main/java/io/github/tonnyl/whatsnew/item/WhatsNewItem.kt
@@ -11,7 +11,7 @@ import kotlinx.android.parcel.Parcelize
 @Parcelize
 data class WhatsNewItem(
         var title: String,
-        var content: String,
+        var content: CharSequence,
         var imageRes: Int
 ) : Parcelable {
 


### PR DESCRIPTION
Previously you had to pass a `String` to the item. However, the underlying
`TextView` only cares about `CharSequence`s. By changing the API of WhatsNew
to support `CharSequences` instead of `String`s, it means users can now make
use of `HtmlComat.fromHTML(...)` to put HTML links in the whats new dialog.

The test app in this repository has been updated to show how this works too.

![image](https://user-images.githubusercontent.com/248565/114179463-5d986a00-9982-11eb-98d9-5aba1c8912f0.png)